### PR TITLE
P13: hardening do ambiente + ADR-009 (Supabase 65xxx / URLs interna vs pública)

### DIFF
--- a/ambiente.bat
+++ b/ambiente.bat
@@ -1,3 +1,4 @@
+REM ambiente.bat
 @echo off
 setlocal EnableExtensions
 
@@ -6,6 +7,8 @@ chcp 65001 >nul
 
 REM Resolve script directory (with trailing backslash)
 set "SCRIPT_DIR=%~dp0"
+
+echo [BAT] Running: powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%ambiente.ps1" %*
 
 powershell.exe ^
   -NoLogo ^

--- a/ambiente.ps1
+++ b/ambiente.ps1
@@ -1,3 +1,4 @@
+# ambiente.ps1
 param(
   [Parameter(Mandatory = $true, Position = 0)]
   [ValidateSet("up", "down", "reset", "restart")]
@@ -6,6 +7,8 @@ param(
   [Parameter(Mandatory = $true, Position = 1)]
   [ValidateSet("dev", "prod")]
   [string]$perfil
+  ,
+  [switch]$Trace
 )
 
 Set-StrictMode -Version Latest
@@ -16,13 +19,27 @@ $ErrorActionPreference = "Stop"
 # ================
 try {
   [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-} catch { }
+}
+catch { }
+
+# ==========================
+# TRACE (step-by-step)
+# ==========================
+if ($Trace) {
+  Set-PSDebug -Trace 1
+  $ts = Get-Date -Format "yyyyMMdd-HHmmss"
+  $logDir = Join-Path $PSScriptRoot "logs"
+  New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+  $transcriptPath = Join-Path $logDir ("ambiente-{0}-{1}-{2}.log" -f $acao, $perfil, $ts)
+  Start-Transcript -Path $transcriptPath -Append | Out-Null
+  Write-Host ("[TRACE] Transcript: {0}" -f $transcriptPath)
+}
 
 # ==========================
 # Helpers (logging/robust)
 # ==========================
 function Write-Section {
-  param([Parameter(Mandatory=$true)][string]$Title)
+  param([Parameter(Mandatory = $true)][string]$Title)
   Write-Host ""
   Write-Host "============================================"
   Write-Host $Title
@@ -30,17 +47,17 @@ function Write-Section {
 }
 
 function Write-Info {
-  param([Parameter(Mandatory=$true)][string]$Message)
+  param([Parameter(Mandatory = $true)][string]$Message)
   Write-Host ("[INFO]  {0}" -f $Message)
 }
 
 function Write-Warn {
-  param([Parameter(Mandatory=$true)][string]$Message)
+  param([Parameter(Mandatory = $true)][string]$Message)
   Write-Host ("[WARN]  {0}" -f $Message)
 }
 
 function Test-CommandExists {
-  param([Parameter(Mandatory=$true)][string]$Name)
+  param([Parameter(Mandatory = $true)][string]$Name)
   try { Get-Command $Name -ErrorAction Stop | Out-Null; return $true }
   catch { return $false }
 }
@@ -52,11 +69,12 @@ function Ensure-Tools {
   try { docker compose version | Out-Null } catch { throw "Docker Compose v2 not available." }
 
   if (-not (Test-CommandExists "npx")) { throw "npx not found in PATH. Install Node.js (includes npx)." }
-  try { & npx supabase --version | Out-Null } catch { throw "Supabase CLI not available via 'npx supabase'." }
+  # Use -y to avoid interactive prompt ("Ok to proceed?") that can hang execution
+  try { & npx -y supabase --version | Out-Null } catch { throw "Supabase CLI not available via 'npx -y supabase'." }
 }
 
 function Import-DotEnv {
-  param([Parameter(Mandatory=$true)][string]$Path)
+  param([Parameter(Mandatory = $true)][string]$Path)
 
   if (-not (Test-Path -LiteralPath $Path)) {
     throw ("File .env not found at: {0}" -f $Path)
@@ -68,7 +86,7 @@ function Import-DotEnv {
     if ($line -notmatch "^[A-Za-z_][A-Za-z0-9_]*=") { return }
 
     $name, $value = $line.Split("=", 2)
-    $name  = $name.Trim()
+    $name = $name.Trim()
     $value = $value.Trim()
 
     if (
@@ -83,12 +101,12 @@ function Import-DotEnv {
 }
 
 function Get-EnvVar {
-  param([Parameter(Mandatory=$true)][string]$Name)
+  param([Parameter(Mandatory = $true)][string]$Name)
   return (Get-Item -Path ("Env:{0}" -f $Name) -ErrorAction SilentlyContinue).Value
 }
 
 function Require-EnvVar {
-  param([Parameter(Mandatory=$true)][string]$Name)
+  param([Parameter(Mandatory = $true)][string]$Name)
   $v = Get-EnvVar $Name
   if (-not $v -or ($v.Trim().Length -eq 0)) {
     throw ("Required var missing in .env: {0}" -f $Name)
@@ -105,11 +123,12 @@ function Validate-Env {
 }
 
 function Test-PortInUse {
-  param([Parameter(Mandatory=$true)][int]$Port)
+  param([Parameter(Mandatory = $true)][int]$Port)
   try {
     $listeners = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop
     return ($listeners.Count -gt 0)
-  } catch {
+  }
+  catch {
     cmd /c "netstat -ano | findstr /R /C:":$Port[ ]" | findstr /I LISTENING" > $null
     return ($LASTEXITCODE -eq 0)
   }
@@ -117,22 +136,35 @@ function Test-PortInUse {
 
 function Invoke-External {
   param(
-    [Parameter(Mandatory=$true)][string]$Title,
-    [Parameter(Mandatory=$true)][scriptblock]$Command,
+    [Parameter(Mandatory = $true)][string]$Title,
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(Mandatory = $true)][string[]]$Arguments,
     [switch]$AllowFail
   )
 
   Write-Info $Title
 
+  $cmdLine = $FilePath + " " + ($Arguments | ForEach-Object {
+      if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ }
+    } | Out-String).Trim()
+
+  Write-Host ("[CMD]   {0}" -f $cmdLine)
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
   $global:LASTEXITCODE = 0
   try {
-    & $Command
-  } catch {
+    & $FilePath @Arguments
+  }
+  catch {
     if ($AllowFail) {
       Write-Warn ("{0} threw an exception (tolerated): {1}" -f $Title, $_.Exception.Message)
       return
     }
     throw
+  }
+  finally {
+    $sw.Stop()
+    Write-Host ("[TIME]  {0} ms" -f $sw.ElapsedMilliseconds)
   }
 
   $code = $LASTEXITCODE
@@ -148,66 +180,54 @@ function Invoke-External {
 # App (docker compose)
 # ==========================
 function App-Up {
-  param([Parameter(Mandatory=$true)][string]$Profile)
-  Invoke-External -Title ("App up ({0}) with build" -f $Profile) -Command {
-    docker compose --profile $Profile up -d --build
-  }
+  param([Parameter(Mandatory = $true)][string]$Profile)
+  $args = @("compose", "--profile", $Profile, "up", "--build")
+  if (-not $Trace) { $args += @("-d") }
+  Invoke-External -Title ("App up ({0})" -f $Profile) -FilePath "docker" -Arguments $args
 }
 
 function App-Down {
-  param([Parameter(Mandatory=$true)][string]$Profile)
+  param([Parameter(Mandatory = $true)][string]$Profile)
   # non-destructive: no --volumes
-  Invoke-External -Title ("App down ({0}) non-destructive" -f $Profile) -Command {
-    docker compose --profile $Profile down --remove-orphans
-  } -AllowFail
+  Invoke-External -Title ("App down ({0}) non-destructive" -f $Profile) -FilePath "docker" -Arguments @("compose", "--profile", $Profile, "down", "--remove-orphans") -AllowFail
 }
 
 function App-Down-WithVolumes {
-  param([Parameter(Mandatory=$true)][string]$Profile)
-  Invoke-External -Title ("App down ({0}) removing volumes (DESTRUCTIVE)" -f $Profile) -Command {
-    docker compose --profile $Profile down --remove-orphans --volumes
-  } -AllowFail
+  param([Parameter(Mandatory = $true)][string]$Profile)
+  Invoke-External -Title ("App down ({0}) removing volumes (DESTRUCTIVE)" -f $Profile) -FilePath "docker" -Arguments @("compose", "--profile", $Profile, "down", "--remove-orphans", "--volumes") -AllowFail
 }
 
 function App-Restart-Rebuild {
-  param([Parameter(Mandatory=$true)][string]$Profile)
+  param([Parameter(Mandatory = $true)][string]$Profile)
 
   # Best-effort stop first (non-destructive). Then force recreate with build.
   App-Down $Profile
 
-  Invoke-External -Title ("App restart ({0}) with rebuild/recreate" -f $Profile) -Command {
-    docker compose --profile $Profile up -d --build --force-recreate
-  }
+  $args = @("compose", "--profile", $Profile, "up", "--build", "--force-recreate")
+  if (-not $Trace) { $args += @("-d") }
+  Invoke-External -Title ("App restart ({0}) with rebuild/recreate" -f $Profile) -FilePath "docker" -Arguments $args
 }
 
 # ==========================
 # Supabase (npx supabase)
 # ==========================
 function Supabase-Start {
-  Invoke-External -Title "Supabase start" -Command {
-    npx supabase start
-  }
+  Invoke-External -Title "Supabase start" -FilePath "npx" -Arguments @("-y", "supabase", "start")
 }
 
 function Supabase-Stop {
   # non-destructive
-  Invoke-External -Title "Supabase stop (non-destructive)" -Command {
-    npx supabase stop
-  } -AllowFail
+  Invoke-External -Title "Supabase stop (non-destructive)" -FilePath "npx" -Arguments @("-y", "supabase", "stop") -AllowFail
 }
 
 function Supabase-Reset-Destructive {
   Write-Section "Supabase RESET (DESTRUCTIVE) - volumes + DB"
 
-  Invoke-External -Title "Supabase stop --no-backup (DESTRUCTIVE)" -Command {
-    npx supabase stop --no-backup
-  }
+  Invoke-External -Title "Supabase stop --no-backup (DESTRUCTIVE)" -FilePath "npx" -Arguments @("-y", "supabase", "stop", "--no-backup")
 
   Supabase-Start
 
-  Invoke-External -Title "Supabase db reset (recreate DB/migrations/seed)" -Command {
-    npx supabase db reset
-  }
+  Invoke-External -Title "Supabase db reset (recreate DB/migrations/seed)" -FilePath "npx" -Arguments @("-y", "supabase", "db", "reset")
 }
 
 # ==========================
@@ -215,11 +235,19 @@ function Supabase-Reset-Destructive {
 # ==========================
 function Cleanup-Network {
   # Keep tolerant; never fail the workflow because of prune/network issues
-  Invoke-External -Title "Cleanup docker networks (tolerant)" -Command {
+  Write-Info "Cleanup docker networks (tolerant)"
+  Write-Host ("[CMD]   docker network ls --format ""{{.Name}}""")
+  try {
     $net = docker network ls --format "{{.Name}}" | Where-Object { $_ -eq "phosio_default" }
-    if ($net) { docker network rm phosio_default | Out-Null }
+    if ($net) {
+      Write-Host ("[CMD]   docker network rm phosio_default")
+      docker network rm phosio_default | Out-Null
+    }
+    Write-Host ("[CMD]   docker network prune -f")
     docker network prune -f | Out-Null
-  } -AllowFail
+  } catch {
+    Write-Warn ("Cleanup docker networks failed but tolerated: {0}" -f $_.Exception.Message)
+  }
 }
 
 function Print-Status {
@@ -232,7 +260,7 @@ function Print-Status {
 }
 
 function Open-Url {
-  param([Parameter(Mandatory=$true)][string]$Url)
+  param([Parameter(Mandatory = $true)][string]$Url)
   try {
     Write-Info ("Opening browser: {0}" -f $Url)
     Start-Process $Url | Out-Null
@@ -253,7 +281,7 @@ try {
 
   # Ports/URLs: dev on 3000; prod external 8080 (container 3000)
   $port = if ($perfil -eq "dev") { 3000 } else { 8080 }
-  $url  = if ($perfil -eq "dev") { "http://jupiter.local:3000" } else { "http://jupiter.local:8080" }
+  $url = if ($perfil -eq "dev") { "http://jupiter.local:3000" } else { "http://jupiter.local:8080" }
 
   if (($acao -eq "up" -or $acao -eq "restart") -and (Test-PortInUse -Port $port)) {
     Write-Warn ("Port {0} seems in use. Bind may fail or environment may already be running." -f $port)
@@ -337,4 +365,9 @@ try {
   Write-Host "[ERROR] Unhandled failure:"
   Write-Host ("        {0}" -f $_.Exception.Message)
   exit 1
+} finally {
+  if ($Trace) {
+    try { Stop-Transcript | Out-Null } catch {}
+    try { Set-PSDebug -Off } catch {}
+  }
 }

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -13,7 +13,7 @@ type ServerEnv = {
 };
 
 type PublicEnv = {
-  SUPABASE_URL: string;
+  SUPABASE_PUBLIC_URL: string;
   SUPABASE_ANON_KEY: string;
 };
 
@@ -47,12 +47,11 @@ export function getServerEnv(): ServerEnv {
 }
 
 export function getPublicEnv(): PublicEnv {
-  const supabaseUrl = required("SUPABASE_URL");
-  const supabasePublicUrl = optional("SUPABASE_PUBLIC_URL") ?? supabaseUrl;
+  const supabasePublicUrl = required("SUPABASE_PUBLIC_URL");
 
   return {
     // Para o browser, SEMPRE a URL pública
-    SUPABASE_URL: supabasePublicUrl,
+    SUPABASE_PUBLIC_URL: supabasePublicUrl,
     SUPABASE_ANON_KEY: required("SUPABASE_ANON_KEY"),
   };
 }

--- a/app/utils/supabase.client.ts
+++ b/app/utils/supabase.client.ts
@@ -4,13 +4,13 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 declare global {
   interface Window {
     __ENV?: {
-      SUPABASE_URL?: string;
+      SUPABASE_PUBLIC_URL?: string;
       SUPABASE_ANON_KEY?: string;
     };
   }
 }
 
-function required(name: "SUPABASE_URL" | "SUPABASE_ANON_KEY"): string {
+function required(name: "SUPABASE_PUBLIC_URL" | "SUPABASE_ANON_KEY"): string {
   const v = window.__ENV?.[name];
   if (!v || typeof v !== "string" || v.trim().length === 0) {
     throw new Error(`Missing public env var in window.__ENV: ${name}`);
@@ -21,7 +21,7 @@ function required(name: "SUPABASE_URL" | "SUPABASE_ANON_KEY"): string {
 // No browser: usa ANON KEY e deixa o Supabase lidar com o fluxo de OAuth e callbacks.
 // Em SSR: NÃO use este client para ler dados sensíveis; prefira um client server-only.
 export function createSupabaseBrowserClient(): SupabaseClient {
-  const url = required("SUPABASE_URL");
+  const url = required("SUPABASE_PUBLIC_URL");
   const key = required("SUPABASE_ANON_KEY");
 
   return createClient(url, key, {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     profiles: ["dev"]
     image: node:20-bookworm-slim
     working_dir: /app
+
     ports:
       - "3000:3000"
       - "3001:3001"
@@ -18,13 +19,23 @@ services:
       - .env
 
     environment:
+      # --- File watching ---
       CHOKIDAR_USEPOLLING: "true"
       CHOKIDAR_INTERVAL: "200"
+
+      # --- Node / Remix ---
       NPM_CONFIG_UPDATE_NOTIFIER: "false"
+      NODE_ENV: development
       HOST: 0.0.0.0
       PORT: "3000"
-      NODE_ENV: development
       REMIX_DEV_ORIGIN: "http://jupiter.local:3001"
+
+      # --- Supabase ---
+      # IMPORTANTE:
+      # - SUPABASE_URL: usado INTERNAMENTE pelo server (container -> supabase)
+      # - SUPABASE_PUBLIC_URL: (vem do .env)
+      #
+      # Em dev local, ambos apontam para o Supabase local
 
     volumes:
       - .:/app
@@ -33,29 +44,33 @@ services:
     command: >
       sh -lc "
         set -e;
+
         echo 'Iniciando Phosio Web...';
 
         NEED_NPM_CI=0;
 
+        # node_modules ausente ou remix não instalado
         if [ ! -d ./node_modules ] || [ ! -x ./node_modules/.bin/remix ]; then
           NEED_NPM_CI=1;
         fi;
 
+        # dependências críticas (native + runtime)
         node -e \"require('sharp')\" >/dev/null 2>&1 || NEED_NPM_CI=1;
+        node -e \"require('archiver')\" >/dev/null 2>&1 || NEED_NPM_CI=1;
 
         if [ \"$$NEED_NPM_CI\" = \"1\" ]; then
-          echo 'Instalando toolchain mínima (para dependências nativas, ex.: sharp)...';
+          echo 'Instalando toolchain mínima (sharp / archiver)…';
+
           apt-get update;
           apt-get install -y --no-install-recommends python3 make g++;
           rm -rf /var/lib/apt/lists/*;
 
-          echo 'Instalando dependências (npm ci)...';
+          echo 'Instalando dependências (npm ci)…';
           npm ci --foreground-scripts --no-audit --no-fund;
         fi;
 
         exec ./node_modules/.bin/remix dev
       "
-
 
   app-prod:
     container_name: phosio-app-prod
@@ -65,8 +80,8 @@ services:
       - .env
     environment:
       NODE_ENV: production
-      PORT: "3000"
       HOST: 0.0.0.0
+      PORT: "3000"
     ports:
       - "8080:3000"
     restart: unless-stopped

--- a/docs/acesso-rede-local.md
+++ b/docs/acesso-rede-local.md
@@ -7,7 +7,7 @@ Este documento descreve as configurações aplicadas para permitir que o ambient
 Para garantir a acessibilidade constante do servidor na rede interna:
 * **IP Estático:** O endereço IP `192.168.68.100` foi reservado para o host no roteador Deco.
 * **Nome do Host:** O dispositivo é identificado na rede pelo nome **jupiter**.
-* **Protocolo mDNS:** Dispositivos móveis (Android/iOS) utilizam o sufixo `.local` para resolução de nomes. O endereço padrão de acesso é `http://jupiter.local:5173`.
+* **Protocolo mDNS:** Dispositivos móveis (Android/iOS) utilizam o sufixo `.local` para resolução de nomes. O endereço padrão de acesso é `http://jupiter.local:3000`.
 
 ## 2. Configuração do Windows (Host jupiter)
 
@@ -19,27 +19,33 @@ O Windows foi configurado para "anunciar" sua presença e permitir tráfego de e
 
 ### Firewall (PowerShell)
 As seguintes regras de entrada foram autorizadas para permitir o tráfego de rede local:
-* **Porta 5173 (Vite):** Permite o tráfego do servidor de desenvolvimento.
-* **Porta 54321 (Supabase):** Permite a comunicação com a API local do Supabase.
+* **Porta 3000 (Remix):** Permite o tráfego do servidor SSR.
+* **Porta 65421 (Supabase Gateway/Kong):** Permite acesso à API local do Supabase.
 * **Porta UDP 5353 (mDNS):** Permite que dispositivos encontrem o host pelo nome `jupiter.local`.
 
 ## 3. Configurações da Aplicação
 
 Os arquivos do projeto foram sincronizados para suportar o acesso via rede local:
 
-### Vite (`vite.config.ts`)
-* **Exposição:** Configurado com `server.host: true` para ouvir em todas as interfaces de rede.
-* **Porta:** Definida como `5173` para desenvolvimento.
-* **Segurança:** O campo `allowedHosts` inclui `"jupiter.local"`, `"jupiter"` e `"localhost"`.
+### Remix (SSR)
+* **Exposição:** O servidor Remix é iniciado com `HOST=0.0.0.0`, permitindo acesso externo.
+* **Porta:** Definida como `3000` no `docker-compose.yml`.
+* **Dev Origin:** `REMIX_DEV_ORIGIN` configurado como `http://jupiter.local:3001`.
 
 ### Supabase (`config.toml`)
-* **URLs de Auth:** O `site_url` e as URLs de redirecionamento foram ajustadas para `http://jupiter.local:5173` para suportar fluxos de autenticação no celular.
+* **URLs de Auth:** `site_url` e `additional_redirect_urls` apontam para `http://jupiter.local:3000`, garantindo que fluxos de autenticação funcionem em dispositivos móveis.
 
 ### Variáveis de Ambiente (`.env`)
-* **Backend:** A variável `VITE_SUPABASE_URL` deve utilizar `http://jupiter.local:54321` para garantir que o navegador de qualquer dispositivo encontre a API no host.
+* **SUPABASE_URL:** Usada **internamente** pelo servidor (container → Supabase), normalmente `http://host.docker.internal:65421`.
+* **SUPABASE_PUBLIC_URL:** URL **exposta ao browser**, ex.: `http://jupiter.local:65421`.
+* **SUPABASE_ANON_KEY:** Chave pública injetada no browser via `env.js`.
+
+### Injeção de variáveis no Browser (`/env.js`)
+* O endpoint `/env.js` expõe apenas variáveis **explicitamente públicas** através de `window.__ENV`.
+* O client Supabase no browser **não** acessa `process.env`.
 
 ### Script de Ambiente (`ambiente.ps1`)
-* **URL de Inicialização:** A variável `$url` foi configurada para abrir o navegador em `http://jupiter.local:5173`.
+* **URL de Inicialização:** O navegador é aberto automaticamente em `http://jupiter.local:3000`.
 * **Regras de Firewall Automáticas:** O script gerencia a abertura das portas necessárias no Windows.
 
 ---
@@ -48,8 +54,8 @@ Os arquivos do projeto foram sincronizados para suportar o acesso via rede local
 
 | Dispositivo | Endereço URL |
 | :--- | :--- |
-| **Desktop Local** | `http://localhost:5173` ou `http://jupiter.local:5173` |
-| **Dispositivos Móveis** | `http://jupiter.local:5173` |
-| **API Supabase (Local)** | `http://jupiter.local:54321` |
+| **Desktop Local** | `http://localhost:3000` ou `http://jupiter.local:3000` |
+| **Dispositivos Móveis** | `http://jupiter.local:3000` |
+| **API Supabase (Local)** | `http://jupiter.local:65421` |
 
 > **Nota:** Se o acesso pelo nome falhar em dispositivos móveis, verifique se o **DNS Particular** do aparelho está desativado.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -5,17 +5,17 @@ project_id = "phosio"
 # =================================================================
 
 [api]
-port = 54321
+port = 65421
 schemas = ["public", "storage", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 max_rows = 1000
 
 [db]
-port = 54322
+port = 65432
 major_version = 15
 
 [studio]
-port = 54323
+port = 65423
 
 # =================================================================
 # CONFIGURAÇÃO DE STORAGE (MÍDIAS)
@@ -36,6 +36,16 @@ allowed_mime_types = ["image/*", "video/*", "application/pdf"]
 site_url = "http://jupiter.local:5173"
 additional_redirect_urls = ["http://jupiter.local:5173","http://jupiter:5173"]
 enable_signup = true
+
+# =================================================================
+# CONFIGURAÇÃO DE CAIXA DE E-MAIL (AUTH)
+# =================================================================
+[inbucket]
+enabled = true
+port = 65424
+smtp_port = 65425
+pop3_port = 65426
+
 
 # =================================================================
 # LOGS E ANALYTICS (OPCIONAL)


### PR DESCRIPTION
## Contexto

Durante a execução do Supabase local em ambiente Windows, foram observadas falhas recorrentes ao bindar portas
na faixa `54321–54324`, mesmo quando aparentemente livres. Além disso, o modelo SSR adotado pelo Phosio
exige uma distinção clara entre comunicação **server-side** (container → Supabase) e **client-side**
(browser → Supabase).

A ausência dessa separação vinha gerando instabilidade operacional, ambiguidade de configuração
e divergência entre código, ambiente e documentação.

---

## Decisão

1. Padronizar o Supabase local para execução em **portas 65xxx** no Windows.
2. Formalizar dois contratos explícitos de URL:
   - `SUPABASE_URL`: uso **interno**, exclusivo do server/container.
   - `SUPABASE_PUBLIC_URL`: uso **público**, consumido pelo browser e dispositivos externos.
3. Restringir a injeção de variáveis no browser (`/env.js`) apenas às variáveis explicitamente públicas.
4. Consolidar scripts e Docker Compose como **fonte canônica** do ambiente de desenvolvimento.
5. Atualizar a documentação arquitetural e de rede local para refletir o estado real do sistema.

---

## Alterações Incluídas

- **refactor(supabase)**  
  Separação explícita entre URL interna e pública no contrato de ambiente.

- **chore(dev-env)**  
  Hardening do ambiente local:
  - scripts `ambiente.*`
  - `docker-compose.yml`
  - portas, bind, inicialização e reset previsíveis.

- **docs(dev-env)**  
  - Novo **ADR-009** documentando a decisão.
  - Atualização do acesso em rede local (`jupiter.local`, Remix :3000, Supabase :65xxx).

---

## Consequências

- Ambiente local estável no Windows, sem conflitos de bind.
- SSR corretamente isolado entre contexto server e browser.
- Redução de “gambiarras” de hostname/porta.
- Documentação alinhada com código e ambiente executável.
- Base sólida para evolução de RLS, Storage e OAuth em cenários multi-dispositivo.

---

Refs: #33
